### PR TITLE
Modificación de estilo de filtro en la tabla del historial de llamadas

### DIFF
--- a/src/styles/historialLlamadas.css
+++ b/src/styles/historialLlamadas.css
@@ -19,7 +19,7 @@
 }
 
 .historial button{
-    background-color: rgb(0,150,173);
+    background-color: #0096AE;
     color: white;
     border: none;
     border-radius: 5px;
@@ -31,7 +31,7 @@
 
 .filtro {
     position: absolute;
-    transform: translateX(-50%);
+    right: 0;
 }
 
 .titulo {


### PR DESCRIPTION
Se corrigió el icono de filtro en la tabla del historial de llamadas porque se veía encimado